### PR TITLE
In 273 / Little fix

### DIFF
--- a/locales/translations/en/basic.ts
+++ b/locales/translations/en/basic.ts
@@ -12,6 +12,7 @@ const errors = {
 export const basic = {
   discard: 'Discard',
   errors: { ...errors },
+  gallery: 'Image in gallery',
   goToTop: 'Go to top',
   logOut: 'Log Out',
   next: 'Next',

--- a/locales/translations/ru/basic.ts
+++ b/locales/translations/ru/basic.ts
@@ -13,6 +13,7 @@ const errors = {
 export const basic = {
   discard: 'Отмена',
   errors: { ...errors },
+  gallery: 'Картинка в карусели',
   goToTop: 'Вверх',
   logOut: 'Выход',
   next: 'Дальше',

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@radix-ui/react-tabs": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.2",
     "@react-oauth/google": "^0.12.1",
-    "axios": "^1.7.7",
+    "axios": "^1.7.9",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: ^0.12.1
         version: 0.12.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       axios:
-        specifier: ^1.7.7
-        version: 1.7.7
+        specifier: ^1.7.9
+        version: 1.7.9
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -2765,8 +2765,8 @@ packages:
     resolution: {integrity: sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==}
     engines: {node: '>=4'}
 
-  axios@1.7.7:
-    resolution: {integrity: sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==}
+  axios@1.7.9:
+    resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -9949,7 +9949,7 @@ snapshots:
 
   axe-core@4.10.0: {}
 
-  axios@1.7.7:
+  axios@1.7.9:
     dependencies:
       follow-redirects: 1.15.9
       form-data: 4.0.0

--- a/src/common/HOC/index.ts
+++ b/src/common/HOC/index.ts
@@ -1,2 +1,2 @@
+export * from './withLoader'
 export * from './withProtection'
-export * from './withServerSide'

--- a/src/common/HOC/withLoader.tsx
+++ b/src/common/HOC/withLoader.tsx
@@ -6,7 +6,7 @@ import { observer } from 'mobx-react-lite'
 
 import { NextPageWithLayout } from './types'
 
-export const withServerSide = <P extends object>(
+export const withLoader = <P extends object>(
   PageComponent: NextPageWithLayout<P>
 ): NextPageWithLayout<P> =>
   observer((props) => {

--- a/src/common/components/swiper/CustomSwiper.tsx
+++ b/src/common/components/swiper/CustomSwiper.tsx
@@ -1,11 +1,11 @@
-import { ImageUrl, Typography, cn, useTranslation } from '@/common'
+import { ImageUrl, cn, useTranslation } from '@/common'
 import Image from 'next/image'
 import { EffectFade, Navigation, Pagination } from 'swiper/modules'
 import { Swiper, SwiperProps, SwiperSlide } from 'swiper/react'
 
 import 'swiper/swiper-bundle.css'
 
-import noPostImage from '/src/assets/images/noUserPosts.svg'
+import { useSwiper } from './useSwiper'
 
 type ImagesTypes = {
   images: Array<{ url: ImageUrl }>
@@ -13,6 +13,7 @@ type ImagesTypes = {
 
 const CustomSwiper = ({ className, images, ...restProps }: ImagesTypes) => {
   const { t } = useTranslation()
+  const { swiperRef } = useSwiper()
 
   return (
     <Swiper
@@ -28,6 +29,7 @@ const CustomSwiper = ({ className, images, ...restProps }: ImagesTypes) => {
       pagination={{
         clickable: true,
       }}
+      ref={swiperRef}
       {...restProps}
       spaceBetween={30}
       watchSlidesProgress

--- a/src/common/components/swiper/CustomSwiper.tsx
+++ b/src/common/components/swiper/CustomSwiper.tsx
@@ -40,7 +40,7 @@ const CustomSwiper = ({ className, images, ...restProps }: ImagesTypes) => {
           key={String(image.url)}
         >
           <Image
-            alt={'picture from post'}
+            alt={t.basic.gallery}
             className={'absolute inset-0 h-full w-full object-cover'}
             fill
             priority

--- a/src/common/components/swiper/CustomSwiper.tsx
+++ b/src/common/components/swiper/CustomSwiper.tsx
@@ -22,6 +22,7 @@ const CustomSwiper = ({ className, images, ...restProps }: ImagesTypes) => {
       keyboard={{
         enabled: true,
       }}
+      loop
       modules={[Navigation, Pagination, EffectFade]}
       navigation
       noSwiping

--- a/src/common/components/swiper/useSwiper.ts
+++ b/src/common/components/swiper/useSwiper.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from 'react'
+
+import { SwiperRef } from 'swiper/react'
+
+export const useSwiper = () => {
+  const swiperRef = useRef<SwiperRef | null>(null)
+
+  useEffect(() => {
+    const swiper = swiperRef.current?.swiper
+
+    if (!swiper) {
+      return
+    }
+
+    const onArrowClick = (e: MouseEvent) => {
+      e.stopPropagation()
+    }
+
+    const nextButton = swiper.navigation.nextEl
+    const prevButton = swiper.navigation.prevEl
+
+    if (nextButton) {
+      nextButton.addEventListener('click', onArrowClick)
+    }
+    if (prevButton) {
+      prevButton.addEventListener('click', onArrowClick)
+    }
+
+    return () => {
+      if (nextButton) {
+        nextButton.removeEventListener('click', onArrowClick)
+      }
+      if (prevButton) {
+        prevButton.removeEventListener('click', onArrowClick)
+      }
+    }
+  }, [])
+
+  return { swiperRef }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,7 @@ export async function getStaticProps(): Promise<
   GetStaticPropsResult<{ posts: PublicPostsDto }>
 > {
   const posts = await publicPostsApi.fetchPublicPosts({
-    pageSize: 4,
+    pageSize: 8,
     sortDirection: 'desc',
   })
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import { withServerSide } from '@/common'
+import { withLoader } from '@/common'
 import {
   PublicPosts,
   PublicPostsDto,
@@ -31,4 +31,4 @@ function PublicPostsPage(
   return <PublicPosts posts={publicPosts} />
 }
 
-export default withServerSide(PublicPostsPage)
+export default withLoader(PublicPostsPage)

--- a/src/pages/profile/[...id]/index.tsx
+++ b/src/pages/profile/[...id]/index.tsx
@@ -1,6 +1,6 @@
 import { PropsWithChildren, useEffect } from 'react'
 
-import { getDeviceScreenWidth, withServerSide } from '@/common'
+import { getDeviceScreenWidth, withLoader } from '@/common'
 import {
   ContentModal,
   PublicPostInfo,
@@ -73,4 +73,4 @@ const ProfilePage = ({
   )
 }
 
-export default withServerSide(ProfilePage)
+export default withLoader(ProfilePage)


### PR DESCRIPTION
- переименование hoc после комментариев на сдаче withServerSive -> withLoader
- повышение версии axios до 1.7.9
- на посадочной странице для незарегистрированных пользователей убран редирект при клике на кнопки свайпера. При задизейбленной кнопке перенаправление происходит, т.к. он проваливается сквозь нее (так работает реализация свайпера)
- зациклена галерея свайпера
- увеличено количество публичных постов с 4 до 8